### PR TITLE
Add proxy header manipulation for Connect upstream connections

### DIFF
--- a/agent/configentry/merge_service_config.go
+++ b/agent/configentry/merge_service_config.go
@@ -183,6 +183,8 @@ func MergeServiceConfig(defaults *structs.ServiceConfigResponse, service *struct
 			Config:               us.Config,
 			MeshGateway:          parsed.MeshGateway,
 			CentrallyConfigured:  true,
+			RequestHeaders:       us.RequestHeaders,
+			ResponseHeaders:      us.ResponseHeaders,
 		}
 	}
 
@@ -238,6 +240,15 @@ func MergeServiceConfig(defaults *structs.ServiceConfigResponse, service *struct
 		// Note that we use the "mesh_gateway" key and not other variants like "MeshGateway" because
 		// UpstreamConfig.MergeInto and ResolveServiceConfig only use "mesh_gateway".
 		delete(us.Config, "mesh_gateway")
+
+		// Merge header modifiers from central config. Local upstream headers
+		// (if set) take precedence over centrally configured ones.
+		if us.RequestHeaders.IsZero() && !remoteCfg.RequestHeaders.IsZero() {
+			us.RequestHeaders = remoteCfg.RequestHeaders
+		}
+		if us.ResponseHeaders.IsZero() && !remoteCfg.ResponseHeaders.IsZero() {
+			us.ResponseHeaders = remoteCfg.ResponseHeaders
+		}
 	}
 
 	// Ensure upstreams present in central config are represented in the local configuration.

--- a/agent/configentry/merge_service_config_test.go
+++ b/agent/configentry/merge_service_config_test.go
@@ -1080,3 +1080,149 @@ func Test_MergeServiceConfig_RateLimit(t *testing.T) {
 		})
 	}
 }
+
+func Test_MergeServiceConfig_UpstreamHeaders(t *testing.T) {
+	zapUpstreamID := structs.PeeredServiceName{
+		ServiceName: structs.NewServiceName("zap", structs.DefaultEnterpriseMetaInDefaultPartition()),
+	}
+
+	tests := []struct {
+		name     string
+		defaults *structs.ServiceConfigResponse
+		service  *structs.NodeService
+		want     *structs.NodeService
+	}{
+		{
+			name: "central upstream headers are propagated to local upstream",
+			defaults: &structs.ServiceConfigResponse{
+				UpstreamConfigs: structs.OpaqueUpstreamConfigs{
+					{
+						Upstream: zapUpstreamID,
+						Config: map[string]interface{}{
+							"protocol": "http",
+						},
+						RequestHeaders: &structs.HTTPHeaderModifiers{
+							Set: map[string]string{
+								"x-source-service": "web",
+							},
+						},
+						ResponseHeaders: &structs.HTTPHeaderModifiers{
+							Remove: []string{"server"},
+						},
+					},
+				},
+			},
+			service: &structs.NodeService{
+				ID:      "foo-proxy",
+				Service: "foo-proxy",
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "foo",
+					DestinationServiceID:   "foo",
+					Upstreams: structs.Upstreams{
+						structs.Upstream{
+							DestinationNamespace: "default",
+							DestinationPartition: "default",
+							DestinationName:      "zap",
+						},
+					},
+				},
+			},
+			want: &structs.NodeService{
+				ID:      "foo-proxy",
+				Service: "foo-proxy",
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "foo",
+					DestinationServiceID:   "foo",
+					Upstreams: structs.Upstreams{
+						structs.Upstream{
+							DestinationNamespace: "default",
+							DestinationPartition: "default",
+							DestinationName:      "zap",
+							Config: map[string]interface{}{
+								"protocol": "http",
+							},
+							RequestHeaders: &structs.HTTPHeaderModifiers{
+								Set: map[string]string{
+									"x-source-service": "web",
+								},
+							},
+							ResponseHeaders: &structs.HTTPHeaderModifiers{
+								Remove: []string{"server"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "local upstream headers take precedence over central",
+			defaults: &structs.ServiceConfigResponse{
+				UpstreamConfigs: structs.OpaqueUpstreamConfigs{
+					{
+						Upstream: zapUpstreamID,
+						Config: map[string]interface{}{
+							"protocol": "http",
+						},
+						RequestHeaders: &structs.HTTPHeaderModifiers{
+							Set: map[string]string{
+								"x-source-service": "web-central",
+							},
+						},
+					},
+				},
+			},
+			service: &structs.NodeService{
+				ID:      "foo-proxy",
+				Service: "foo-proxy",
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "foo",
+					DestinationServiceID:   "foo",
+					Upstreams: structs.Upstreams{
+						structs.Upstream{
+							DestinationNamespace: "default",
+							DestinationPartition: "default",
+							DestinationName:      "zap",
+							RequestHeaders: &structs.HTTPHeaderModifiers{
+								Set: map[string]string{
+									"x-source-service": "web-local",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &structs.NodeService{
+				ID:      "foo-proxy",
+				Service: "foo-proxy",
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "foo",
+					DestinationServiceID:   "foo",
+					Upstreams: structs.Upstreams{
+						structs.Upstream{
+							DestinationNamespace: "default",
+							DestinationPartition: "default",
+							DestinationName:      "zap",
+							Config: map[string]interface{}{
+								"protocol": "http",
+							},
+							// Local headers take precedence, so central headers are not used
+							RequestHeaders: &structs.HTTPHeaderModifiers{
+								Set: map[string]string{
+									"x-source-service": "web-local",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MergeServiceConfig(tt.defaults, tt.service)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/agent/configentry/resolve.go
+++ b/agent/configentry/resolve.go
@@ -233,6 +233,26 @@ func ComputeResolvedServiceConfig(
 		resolvedConfigs[wildcard] = wildcardUpstreamDefaults
 	}
 
+	// Store wildcard headers so they are included in the OpaqueUpstreamConfig
+	// for the wildcard entry, making them available to all upstreams as defaults.
+	// resolvedHeaders tracks the merged request/response header modifiers for
+	// each upstream, resolved separately from the opaque config map.
+	type resolvedHeaderModifiers struct {
+		RequestHeaders  *structs.HTTPHeaderModifiers
+		ResponseHeaders *structs.HTTPHeaderModifiers
+	}
+	resolvedHeadersByUpstream := make(map[structs.PeeredServiceName]resolvedHeaderModifiers)
+
+	// Resolve wildcard upstream headers from defaults.
+	var wildcardHeaders resolvedHeaderModifiers
+	if upstreamDefaults != nil {
+		wildcardHeaders.RequestHeaders = upstreamDefaults.RequestHeaders
+		wildcardHeaders.ResponseHeaders = upstreamDefaults.ResponseHeaders
+		if !upstreamDefaults.RequestHeaders.IsZero() || !upstreamDefaults.ResponseHeaders.IsZero() {
+			resolvedHeadersByUpstream[wildcard] = wildcardHeaders
+		}
+	}
+
 	for upstream := range seenUpstreams {
 		resolvedCfg := make(map[string]interface{})
 
@@ -295,6 +315,23 @@ func ComputeResolvedServiceConfig(
 		if len(resolvedCfg) > 0 {
 			resolvedConfigs[upstream] = resolvedCfg
 		}
+
+		// Resolve header modifiers: start with defaults, then merge overrides.
+		hdrs := wildcardHeaders
+		if override, ok := upstreamOverrides[upstream]; ok && override != nil {
+			var err error
+			hdrs.RequestHeaders, err = structs.MergeHTTPHeaderModifiers(hdrs.RequestHeaders, override.RequestHeaders)
+			if err != nil {
+				return nil, fmt.Errorf("failed to merge request headers for upstream %s: %v", upstream.String(), err)
+			}
+			hdrs.ResponseHeaders, err = structs.MergeHTTPHeaderModifiers(hdrs.ResponseHeaders, override.ResponseHeaders)
+			if err != nil {
+				return nil, fmt.Errorf("failed to merge response headers for upstream %s: %v", upstream.String(), err)
+			}
+		}
+		if !hdrs.RequestHeaders.IsZero() || !hdrs.ResponseHeaders.IsZero() {
+			resolvedHeadersByUpstream[upstream] = hdrs
+		}
 	}
 
 	// don't allocate the slices just to not fill them
@@ -305,8 +342,12 @@ func ComputeResolvedServiceConfig(
 	thisReply.UpstreamConfigs = make(structs.OpaqueUpstreamConfigs, 0, len(resolvedConfigs))
 
 	for us, conf := range resolvedConfigs {
-		thisReply.UpstreamConfigs = append(thisReply.UpstreamConfigs,
-			structs.OpaqueUpstreamConfig{Upstream: us, Config: conf})
+		ouc := structs.OpaqueUpstreamConfig{Upstream: us, Config: conf}
+		if hdrs, ok := resolvedHeadersByUpstream[us]; ok {
+			ouc.RequestHeaders = hdrs.RequestHeaders
+			ouc.ResponseHeaders = hdrs.ResponseHeaders
+		}
+		thisReply.UpstreamConfigs = append(thisReply.UpstreamConfigs, ouc)
 	}
 
 	return &thisReply, nil

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -1027,6 +1027,18 @@ type UpstreamConfig struct {
 	// BalanceOutboundConnections indicates how the proxy should attempt to distribute
 	// connections across worker threads. Only used by envoy proxies.
 	BalanceOutboundConnections string `json:",omitempty" alias:"balance_outbound_connections"`
+
+	// RequestHeaders is a set of header modification rules that are applied to
+	// requests routed to this upstream. This allows operators to add, set, or
+	// remove HTTP headers for traffic flowing to specific upstreams. Only valid
+	// for http, http2, and grpc protocols.
+	RequestHeaders *HTTPHeaderModifiers `json:",omitempty" alias:"request_headers"`
+
+	// ResponseHeaders is a set of header modification rules that are applied to
+	// responses from this upstream. This allows operators to add, set, or remove
+	// HTTP headers for traffic returning from specific upstreams. Only valid for
+	// http, http2, and grpc protocols.
+	ResponseHeaders *HTTPHeaderModifiers `json:",omitempty" alias:"response_headers"`
 }
 
 func (cfg UpstreamConfig) Clone() UpstreamConfig {
@@ -1034,6 +1046,17 @@ func (cfg UpstreamConfig) Clone() UpstreamConfig {
 
 	cfg2.Limits = cfg.Limits.Clone()
 	cfg2.PassiveHealthCheck = cfg.PassiveHealthCheck.Clone()
+
+	var err error
+	cfg2.RequestHeaders, err = cfg.RequestHeaders.Clone()
+	if err != nil {
+		// Clone uses copystructure which should not fail for this type.
+		panic(fmt.Sprintf("failed to clone RequestHeaders: %v", err))
+	}
+	cfg2.ResponseHeaders, err = cfg.ResponseHeaders.Clone()
+	if err != nil {
+		panic(fmt.Sprintf("failed to clone ResponseHeaders: %v", err))
+	}
 
 	return cfg2
 }
@@ -1304,8 +1327,10 @@ func (ul UpstreamLimits) Validate() error {
 }
 
 type OpaqueUpstreamConfig struct {
-	Upstream PeeredServiceName
-	Config   map[string]interface{}
+	Upstream        PeeredServiceName
+	Config          map[string]interface{}
+	RequestHeaders  *HTTPHeaderModifiers `json:",omitempty"`
+	ResponseHeaders *HTTPHeaderModifiers `json:",omitempty"`
 }
 type OpaqueUpstreamConfigs []OpaqueUpstreamConfig
 

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -294,6 +294,18 @@ type ConnectProxyConfig struct {
 
 	// AccessLogs configures the output and format of Envoy access logs
 	AccessLogs AccessLogsConfig `json:",omitempty" alias:"access_logs"`
+
+	// RequestHeaders is a set of header modification rules applied to all
+	// outbound requests from this proxy. This allows operators to add, set, or
+	// remove HTTP headers for all traffic leaving the sidecar. Only valid for
+	// http, http2, and grpc protocols.
+	RequestHeaders *HTTPHeaderModifiers `json:",omitempty" alias:"request_headers"`
+
+	// ResponseHeaders is a set of header modification rules applied to all
+	// inbound responses to this proxy. This allows operators to add, set, or
+	// remove HTTP headers for all traffic returning through the sidecar. Only
+	// valid for http, http2, and grpc protocols.
+	ResponseHeaders *HTTPHeaderModifiers `json:",omitempty" alias:"response_headers"`
 }
 
 func (t *ConnectProxyConfig) UnmarshalJSON(data []byte) (err error) {
@@ -491,6 +503,14 @@ type Upstream struct {
 	// CentrallyConfigured indicates whether the upstream was defined in a proxy
 	// instance registration or whether it was generated from a config entry.
 	CentrallyConfigured bool `json:",omitempty" bexpr:"-"`
+
+	// RequestHeaders is a set of header modification rules applied to requests
+	// to this upstream. Resolved from service-defaults UpstreamConfig.
+	RequestHeaders *HTTPHeaderModifiers `json:",omitempty" alias:"request_headers"`
+
+	// ResponseHeaders is a set of header modification rules applied to responses
+	// from this upstream. Resolved from service-defaults UpstreamConfig.
+	ResponseHeaders *HTTPHeaderModifiers `json:",omitempty" alias:"response_headers"`
 }
 
 func (t *Upstream) UnmarshalJSON(data []byte) (err error) {

--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -86,6 +86,13 @@ func (s *ResourceGenerator) routesForConnectProxy(cfgSnap *proxycfg.ConfigSnapsh
 			continue
 		}
 
+		// Inject upstream-level header manipulation from service-defaults
+		// UpstreamConfig and proxy-level ConnectProxyConfig. These are applied
+		// at the virtual host level so they affect all routes for this upstream.
+		if err := injectUpstreamHeaderManip(cfgSnap, uid, virtualHost); err != nil {
+			return nil, fmt.Errorf("failed to apply upstream header manipulation: %v", err)
+		}
+
 		route := &envoy_route_v3.RouteConfiguration{
 			Name:         uid.EnvoyID(),
 			VirtualHosts: []*envoy_route_v3.VirtualHost{virtualHost},
@@ -1281,6 +1288,81 @@ func injectHeaderManipToRoute(dest *structs.ServiceRouteDestination, r *envoy_ro
 		r.ResponseHeadersToRemove = append(
 			r.ResponseHeadersToRemove,
 			dest.ResponseHeaders.Remove...,
+		)
+	}
+	return nil
+}
+
+// injectUpstreamHeaderManip merges proxy-level and upstream-level header
+// modification rules and injects them into the Envoy VirtualHost. The merge
+// order gives upstream-specific config precedence over proxy-wide config.
+func injectUpstreamHeaderManip(cfgSnap *proxycfg.ConfigSnapshot, uid proxycfg.UpstreamID, vh *envoy_route_v3.VirtualHost) error {
+	if cfgSnap.Kind != structs.ServiceKindConnectProxy {
+		return nil
+	}
+
+	// Start with proxy-level headers (lowest precedence).
+	reqHeaders := cfgSnap.Proxy.RequestHeaders
+	respHeaders := cfgSnap.Proxy.ResponseHeaders
+
+	// Merge in upstream-level headers. These are resolved from service-defaults
+	// UpstreamConfig and carried on the Upstream struct in the snapshot.
+	// Upstream-specific headers take precedence over proxy-wide headers.
+	upstream, _ := cfgSnap.ConnectProxy.GetUpstream(uid, &cfgSnap.ProxyID.EnterpriseMeta)
+	if upstream != nil {
+		if !upstream.RequestHeaders.IsZero() {
+			merged, err := structs.MergeHTTPHeaderModifiers(reqHeaders, upstream.RequestHeaders)
+			if err != nil {
+				return fmt.Errorf("failed to merge request headers: %v", err)
+			}
+			reqHeaders = merged
+		}
+		if !upstream.ResponseHeaders.IsZero() {
+			merged, err := structs.MergeHTTPHeaderModifiers(respHeaders, upstream.ResponseHeaders)
+			if err != nil {
+				return fmt.Errorf("failed to merge response headers: %v", err)
+			}
+			respHeaders = merged
+		}
+	}
+
+	if reqHeaders.IsZero() && respHeaders.IsZero() {
+		return nil
+	}
+
+	return injectHTTPHeaderManipToVirtualHost(reqHeaders, respHeaders, vh)
+}
+
+// injectHTTPHeaderManipToVirtualHost applies the given request/response header
+// modifiers to an Envoy VirtualHost. This is a generic helper used by both
+// upstream-level and ingress-level header injection.
+func injectHTTPHeaderManipToVirtualHost(reqHeaders, respHeaders *structs.HTTPHeaderModifiers, vh *envoy_route_v3.VirtualHost) error {
+	if !reqHeaders.IsZero() {
+		vh.RequestHeadersToAdd = append(
+			vh.RequestHeadersToAdd,
+			makeHeadersValueOptions(reqHeaders.Add, true)...,
+		)
+		vh.RequestHeadersToAdd = append(
+			vh.RequestHeadersToAdd,
+			makeHeadersValueOptions(reqHeaders.Set, false)...,
+		)
+		vh.RequestHeadersToRemove = append(
+			vh.RequestHeadersToRemove,
+			reqHeaders.Remove...,
+		)
+	}
+	if !respHeaders.IsZero() {
+		vh.ResponseHeadersToAdd = append(
+			vh.ResponseHeadersToAdd,
+			makeHeadersValueOptions(respHeaders.Add, true)...,
+		)
+		vh.ResponseHeadersToAdd = append(
+			vh.ResponseHeadersToAdd,
+			makeHeadersValueOptions(respHeaders.Set, false)...,
+		)
+		vh.ResponseHeadersToRemove = append(
+			vh.ResponseHeadersToRemove,
+			respHeaders.Remove...,
 		)
 	}
 	return nil

--- a/agent/xds/upstream_headers_test.go
+++ b/agent/xds/upstream_headers_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package xds
+
+import (
+	"testing"
+
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func TestInjectHTTPHeaderManipToVirtualHost(t *testing.T) {
+	tests := []struct {
+		name        string
+		reqHeaders  *structs.HTTPHeaderModifiers
+		respHeaders *structs.HTTPHeaderModifiers
+		expectReqAdd    int
+		expectReqRemove int
+		expectRespAdd   int
+		expectRespRemove int
+	}{
+		{
+			name:        "nil headers",
+			reqHeaders:  nil,
+			respHeaders: nil,
+		},
+		{
+			name: "request headers only - set",
+			reqHeaders: &structs.HTTPHeaderModifiers{
+				Set: map[string]string{
+					"x-source-service": "web",
+				},
+			},
+			respHeaders:     nil,
+			expectReqAdd:    1,
+			expectReqRemove: 0,
+		},
+		{
+			name: "request headers - add and remove",
+			reqHeaders: &structs.HTTPHeaderModifiers{
+				Add: map[string]string{
+					"x-trace-id": "abc123",
+				},
+				Remove: []string{"x-internal-only"},
+			},
+			respHeaders:     nil,
+			expectReqAdd:    1,
+			expectReqRemove: 1,
+		},
+		{
+			name:       "response headers only",
+			reqHeaders: nil,
+			respHeaders: &structs.HTTPHeaderModifiers{
+				Set: map[string]string{
+					"x-served-by": "consul-mesh",
+				},
+				Remove: []string{"server"},
+			},
+			expectRespAdd:    1,
+			expectRespRemove: 1,
+		},
+		{
+			name: "both request and response headers",
+			reqHeaders: &structs.HTTPHeaderModifiers{
+				Set: map[string]string{
+					"x-source": "web",
+				},
+				Add: map[string]string{
+					"x-request-start": "t=now",
+				},
+				Remove: []string{"x-debug"},
+			},
+			respHeaders: &structs.HTTPHeaderModifiers{
+				Set: map[string]string{
+					"x-envoy-upstream-service-time": "true",
+				},
+			},
+			expectReqAdd:     2,
+			expectReqRemove:  1,
+			expectRespAdd:    1,
+			expectRespRemove: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vh := &envoy_route_v3.VirtualHost{
+				Name:    "test",
+				Domains: []string{"*"},
+			}
+
+			err := injectHTTPHeaderManipToVirtualHost(tt.reqHeaders, tt.respHeaders, vh)
+			require.NoError(t, err)
+
+			require.Len(t, vh.RequestHeadersToAdd, tt.expectReqAdd)
+			require.Len(t, vh.RequestHeadersToRemove, tt.expectReqRemove)
+			require.Len(t, vh.ResponseHeadersToAdd, tt.expectRespAdd)
+			require.Len(t, vh.ResponseHeadersToRemove, tt.expectRespRemove)
+		})
+	}
+}
+
+func TestMakeHeadersValueOptions_AppendAction(t *testing.T) {
+	// Verify that "add" mode uses APPEND and "set" mode uses OVERWRITE
+	addOpts := makeHeadersValueOptions(map[string]string{"x-foo": "bar"}, true)
+	require.Len(t, addOpts, 1)
+	// Default is APPEND_IF_EXISTS_OR_ADD (value 0)
+	require.Equal(t, envoy_core_v3.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD, addOpts[0].AppendAction)
+
+	setOpts := makeHeadersValueOptions(map[string]string{"x-foo": "bar"}, false)
+	require.Len(t, setOpts, 1)
+	require.Equal(t, envoy_core_v3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD, setOpts[0].AppendAction)
+}

--- a/api/agent.go
+++ b/api/agent.go
@@ -208,6 +208,8 @@ type AgentServiceConnectProxyConfig struct {
 	MeshGateway            MeshGatewayConfig       `json:",omitempty"`
 	Expose                 ExposeConfig            `json:",omitempty"`
 	AccessLogs             *AccessLogsConfig       `json:",omitempty"`
+	RequestHeaders         *HTTPHeaderModifiers    `json:",omitempty"`
+	ResponseHeaders        *HTTPHeaderModifiers    `json:",omitempty"`
 }
 
 const (

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -262,6 +262,14 @@ type UpstreamConfig struct {
 	// BalanceOutboundConnections indicates that the proxy should attempt to evenly distribute
 	// outbound connections across worker threads. Only used by envoy proxies.
 	BalanceOutboundConnections string `json:",omitempty" alias:"balance_outbound_connections"`
+
+	// RequestHeaders is a set of header modification rules applied to requests
+	// routed to this upstream.
+	RequestHeaders *HTTPHeaderModifiers `json:",omitempty" alias:"request_headers"`
+
+	// ResponseHeaders is a set of header modification rules applied to responses
+	// from this upstream.
+	ResponseHeaders *HTTPHeaderModifiers `json:",omitempty" alias:"response_headers"`
 }
 
 // DestinationConfig represents a virtual service, i.e. one that is external to Consul

--- a/proto/private/pbconfigentry/config_entry.gen.go
+++ b/proto/private/pbconfigentry/config_entry.gen.go
@@ -2681,6 +2681,16 @@ func UpstreamConfigToStructs(s *UpstreamConfig, t *structs.UpstreamConfig) {
 		MeshGatewayConfigToStructs(s.MeshGateway, &t.MeshGateway)
 	}
 	t.BalanceOutboundConnections = s.BalanceOutboundConnections
+	if s.RequestHeaders != nil {
+		var x structs.HTTPHeaderModifiers
+		HTTPHeaderModifiersToStructs(s.RequestHeaders, &x)
+		t.RequestHeaders = &x
+	}
+	if s.ResponseHeaders != nil {
+		var x structs.HTTPHeaderModifiers
+		HTTPHeaderModifiersToStructs(s.ResponseHeaders, &x)
+		t.ResponseHeaders = &x
+	}
 }
 func UpstreamConfigFromStructs(t *structs.UpstreamConfig, s *UpstreamConfig) {
 	if s == nil {
@@ -2709,6 +2719,16 @@ func UpstreamConfigFromStructs(t *structs.UpstreamConfig, s *UpstreamConfig) {
 		s.MeshGateway = &x
 	}
 	s.BalanceOutboundConnections = t.BalanceOutboundConnections
+	if t.RequestHeaders != nil {
+		var x HTTPHeaderModifiers
+		HTTPHeaderModifiersFromStructs(t.RequestHeaders, &x)
+		s.RequestHeaders = &x
+	}
+	if t.ResponseHeaders != nil {
+		var x HTTPHeaderModifiers
+		HTTPHeaderModifiersFromStructs(t.ResponseHeaders, &x)
+		s.ResponseHeaders = &x
+	}
 }
 func UpstreamConfigurationToStructs(s *UpstreamConfiguration, t *structs.UpstreamConfiguration) {
 	if s == nil {

--- a/proto/private/pbconfigentry/config_entry.pb.go
+++ b/proto/private/pbconfigentry/config_entry.pb.go
@@ -4572,6 +4572,8 @@ type UpstreamConfig struct {
 	MeshGateway                *MeshGatewayConfig  `protobuf:"bytes,9,opt,name=MeshGateway,proto3" json:"MeshGateway,omitempty"`
 	BalanceOutboundConnections string              `protobuf:"bytes,10,opt,name=BalanceOutboundConnections,proto3" json:"BalanceOutboundConnections,omitempty"`
 	Peer                       string              `protobuf:"bytes,11,opt,name=Peer,proto3" json:"Peer,omitempty"`
+	RequestHeaders             *HTTPHeaderModifiers `protobuf:"bytes,12,opt,name=RequestHeaders,proto3" json:"RequestHeaders,omitempty"`
+	ResponseHeaders            *HTTPHeaderModifiers `protobuf:"bytes,13,opt,name=ResponseHeaders,proto3" json:"ResponseHeaders,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
@@ -4681,6 +4683,20 @@ func (x *UpstreamConfig) GetPeer() string {
 		return x.Peer
 	}
 	return ""
+}
+
+func (x *UpstreamConfig) GetRequestHeaders() *HTTPHeaderModifiers {
+	if x != nil {
+		return x.RequestHeaders
+	}
+	return nil
+}
+
+func (x *UpstreamConfig) GetResponseHeaders() *HTTPHeaderModifiers {
+	if x != nil {
+		return x.ResponseHeaders
+	}
+	return nil
 }
 
 // mog annotation:

--- a/proto/private/pbconfigentry/config_entry.proto
+++ b/proto/private/pbconfigentry/config_entry.proto
@@ -712,6 +712,8 @@ message UpstreamConfig {
   MeshGatewayConfig MeshGateway = 9;
   string BalanceOutboundConnections = 10;
   string Peer = 11;
+  HTTPHeaderModifiers RequestHeaders = 12;
+  HTTPHeaderModifiers ResponseHeaders = 13;
 }
 
 // mog annotation:


### PR DESCRIPTION
## Summary

- Adds `RequestHeaders` and `ResponseHeaders` fields to `ConnectProxyConfig` (proxy-level) and `UpstreamConfig` (per-upstream level in service-defaults), allowing HTTP header Add/Set/Remove operations for Connect service mesh traffic
- Threads header configuration through the service config resolution pipeline (`resolve.go` → `OpaqueUpstreamConfig` → `merge_service_config.go` → `Upstream` struct), protobuf definitions, and API structs
- Injects upstream-level headers into Envoy VirtualHost config via new `injectUpstreamHeaderManip()` in xDS route generation, with proper merge precedence: proxy-level < upstream-level < discovery chain route/split headers

## Motivation

Previously, adding custom headers to service-to-service traffic required creating a `service-router` config entry even for simple cases like injecting a source-service identity header. This change enables header manipulation directly in sidecar proxy registration or `service-defaults` upstream config:

```hcl
Kind = "service-defaults"
Name = "web"
UpstreamConfig {
  Overrides = [
    {
      Name = "api"
      RequestHeaders {
        Set { "x-source-service" = "web" }
      }
    }
  ]
}
```

## Files changed

| Area | Files | What changed |
|------|-------|-------------|
| Structs | `agent/structs/config_entry.go`, `connect_proxy_config.go` | Added `RequestHeaders`/`ResponseHeaders` to `UpstreamConfig`, `ConnectProxyConfig`, `Upstream`, `OpaqueUpstreamConfig` |
| API | `api/agent.go`, `api/config_entry.go` | Mirrored new fields in public API structs |
| Proto | `config_entry.proto`, `.pb.go`, `.gen.go` | Added fields 12-13 to `UpstreamConfig` message with conversion functions |
| Config resolution | `agent/configentry/resolve.go` | Resolves and merges header modifiers from service-defaults upstream defaults/overrides |
| Config merging | `agent/configentry/merge_service_config.go` | Propagates resolved headers into `Upstream` structs during service config merge |
| xDS routes | `agent/xds/routes.go` | New `injectUpstreamHeaderManip()` and `injectHTTPHeaderManipToVirtualHost()` functions |
| Tests | `upstream_headers_test.go`, `merge_service_config_test.go` | Unit tests for header injection and merge propagation |

## Test plan

- [ ] Verify `injectHTTPHeaderManipToVirtualHost` correctly injects Add/Set/Remove headers to Envoy VirtualHost
- [ ] Verify `makeHeadersValueOptions` uses correct `AppendAction` for add vs set
- [ ] Verify central upstream headers propagate through `MergeServiceConfig` to local upstreams
- [ ] Verify local upstream headers take precedence over centrally configured ones
- [ ] Integration test: register service with proxy-level headers, verify Envoy config via `envoy_public_listener` xDS dump
- [ ] Integration test: configure service-defaults with upstream header overrides, verify headers appear in upstream route config

🤖 Generated with [Claude Code](https://claude.com/claude-code)